### PR TITLE
User friendly error reporting from sops

### DIFF
--- a/SopsSecretGenerator.go
+++ b/SopsSecretGenerator.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pkg/errors"
+	"go.mozilla.org/sops"
 	sopscommon "go.mozilla.org/sops/cmd/sops/common"
 	sopsdecrypt "go.mozilla.org/sops/decrypt"
 	"gopkg.in/yaml.v2"
@@ -72,7 +73,11 @@ func main() {
 
 	output, err := processSopsSecretGenerator(os.Args[1])
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if sopsErr, ok := errors.Cause(err).(sops.UserError); ok {
+			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n%s\n", err, sopsErr.UserError())
+		} else {
+			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		os.Exit(2)
 	}
 	fmt.Print(output)


### PR DESCRIPTION
Previously, when users misconfigured their credentials (AWS for example), they will get confused about the error message:

```
Error: file source files/config.toml: Error getting data key: 0 successful groups required, got 0
```

Now, after this patch:

```
Error: file source files/config.toml: Error getting data key: 0 successful groups required, got 0
Failed to get the data key required to decrypt the SOPS file.

Group 0: FAILED
  arn:aws-cn:kms:cn-north-1:XXXXXXXXXX:key/XXXXXXXXXXXXXXXXXXXXXXXXXXXx: FAILED
    - | Error decrypting key: AccessDeniedException: The ciphertext
      | refers to a customer master key that does not exist, does
      | not exist in this region, or you are not allowed to access.
      | 	status code: 400, request id:
      | XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

Recovery failed because no master key was able to decrypt the file. In
order for SOPS to recover the file, at least one key has to be successful,
but none were.
...
```
 