### PR TITLE
Add arm64 arch to released binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,10 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
 
 archives:
   - format: binary


### PR DESCRIPTION
For some reason this change got lost in history.

Closes #20.