### PR TITLE
Strip local-config and function annotations

### DIFF
--- a/SopsSecretGenerator.go
+++ b/SopsSecretGenerator.go
@@ -30,6 +30,10 @@ const kind = "SopsSecretGenerator"
 const oldKind = "SopsSecret"
 
 var utf8bom = []byte{0xEF, 0xBB, 0xBF}
+var stripAnnotations = map[string]bool{
+	"config.kubernetes.io/local-config": true,
+	"config.kubernetes.io/function":     true,
+}
 
 type kvMap map[string]string
 
@@ -177,6 +181,9 @@ func generateSecret(sopsSecret SopsSecretGenerator) (Secret, error) {
 
 	annotations := make(kvMap)
 	for k, v := range sopsSecret.Annotations {
+		if _, skip := stripAnnotations[k]; skip {
+			continue
+		}
 		annotations[k] = v
 	}
 	if !sopsSecret.DisableNameSuffixHash {

--- a/SopsSecretGenerator_test.go
+++ b/SopsSecretGenerator_test.go
@@ -80,6 +80,8 @@ func Test_GenerateKRMManifest(t *testing.T) {
 				kind: Secret
 				metadata:
 				  name: secret-from-env
+				  annotations:
+				    config.k8s.io/id: "2"
 				data:
 				  VAR_ENV: dmFsX2Vudg==
 			`), "\n"),
@@ -93,6 +95,8 @@ func Test_GenerateKRMManifest(t *testing.T) {
 				kind: Secret
 				metadata:
 				  name: secret-from-file
+				  annotations:
+				    config.k8s.io/id: "1"
 				data:
 				  file.txt: c2VjcmV0Cg==
 			`), "\n"),

--- a/testdata/krm-function-input.yaml
+++ b/testdata/krm-function-input.yaml
@@ -6,6 +6,12 @@ items:
 - apiVersion: goabout.com/v1beta1
   kind: SopsSecretGenerator
   metadata:
+    annotations:
+      config.kubernetes.io/function: |
+        exec:
+          path: SopsSecretGenerator
+      config.kubernetes.io/local-config: 'true'
+      config.k8s.io/id: '1'
     name: secret-from-file
   disableNameSuffixHash: true
   files:
@@ -13,6 +19,12 @@ items:
 - apiVersion: goabout.com/v1beta1
   kind: SopsSecretGenerator
   metadata:
+    annotations:
+      config.kubernetes.io/function: |
+        exec:
+          path: SopsSecretGenerator
+      config.kubernetes.io/local-config: 'true'
+      config.k8s.io/id: '2'
     name: secret-from-env
   disableNameSuffixHash: true
   envs:


### PR DESCRIPTION
When kustomize calls a KRM function, the input includes a set of
annotations. Many of these should be passed through to the resulting
generated object, but ’config.kubernetes.io/local-config` must be
stripped or the resulting object will be considered "local" and not
rendered as output to kustomize. Likewise, leaving the generator
configuration in `config.kubernetes.io/function` is not needed and may
be problematic if passed on to further generators.

Fixes #36

Signed-off-by: Jim Ramsay <i.am@jimramsay.com>
