### PR TITLE
more krm tests

### DIFF
--- a/SopsSecretGenerator.go
+++ b/SopsSecretGenerator.go
@@ -126,7 +126,7 @@ func main() {
 // generateKRMManifest reads ResourceList with SopsSecretGenerator items
 // and returns ResourceList with Secret items.
 func generateKRMManifest(rl *fn.ResourceList) (bool, error) {
-	var generatedSecrets []*fn.KubeObject
+	var generatedSecrets fn.KubeObjects
 
 	for _, sopsSecretGeneratorManifest := range rl.Items {
 		secretManifest := generateSecretManifest([]byte(sopsSecretGeneratorManifest.String()))

--- a/SopsSecretGenerator.go
+++ b/SopsSecretGenerator.go
@@ -118,7 +118,15 @@ func main() {
 			usage()
 		}
 
-		secretManifest := generateSecretManifest(sopsSecretGeneratorManifest)
+		secretManifest, err := processSopsSecretGenerator(sopsSecretGeneratorManifest)
+		if err != nil {
+			if sopsErr, ok := errors.Cause(err).(sops.UserError); ok {
+				_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n%s\n", err, sopsErr.UserError())
+			} else {
+				_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
+			os.Exit(2)
+		}
 		fmt.Print(secretManifest)
 	}
 }
@@ -129,10 +137,15 @@ func generateKRMManifest(rl *fn.ResourceList) (bool, error) {
 	var generatedSecrets fn.KubeObjects
 
 	for _, sopsSecretGeneratorManifest := range rl.Items {
-		secretManifest := generateSecretManifest([]byte(sopsSecretGeneratorManifest.String()))
+		secretManifest, err := processSopsSecretGenerator([]byte(sopsSecretGeneratorManifest.String()))
+		if err != nil {
+			rl.LogResult(err)
+			return false, err
+		}
 
 		secretKubeObject, err := fn.ParseKubeObject([]byte(secretManifest))
 		if err != nil {
+			rl.LogResult(err)
 			return false, err
 		}
 
@@ -142,19 +155,6 @@ func generateKRMManifest(rl *fn.ResourceList) (bool, error) {
 	rl.Items = generatedSecrets
 
 	return true, nil
-}
-
-func generateSecretManifest(manifestContent []byte) string {
-	output, err := processSopsSecretGenerator(manifestContent)
-	if err != nil {
-		if sopsErr, ok := errors.Cause(err).(sops.UserError); ok {
-			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n%s\n", err, sopsErr.UserError())
-		} else {
-			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		}
-		os.Exit(2)
-	}
-	return output
 }
 
 func processSopsSecretGenerator(manifestContent []byte) (string, error) {

--- a/SopsSecretGenerator_test.go
+++ b/SopsSecretGenerator_test.go
@@ -117,6 +117,11 @@ func Test_GenerateKRMManifest(t *testing.T) {
 				`), "\n"),
 			}, false},
 		},
+		{
+			"Malformed input",
+			args{"testdata/krm-error.yaml"},
+			wanted{[]string{}, true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/SopsSecretGenerator_test.go
+++ b/SopsSecretGenerator_test.go
@@ -63,44 +63,59 @@ func setupGnuPG() error {
 
 func Test_GenerateKRMManifest(t *testing.T) {
 	type args struct {
-		rlFile    string
-		itemIndex int
+		rlFile string
+	}
+	type wanted struct {
+		items []string
+		err   bool
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name string
+		args args
+		want wanted
 	}{
 		{
-			"SecretFromEnv",
-			args{"testdata/krm-function-input.yaml", 0},
-			strings.TrimLeft(dedent.Dedent(`
-				apiVersion: v1
-				kind: Secret
-				metadata:
-				  name: secret-from-env
-				  annotations:
-				    config.k8s.io/id: "2"
-				data:
-				  VAR_ENV: dmFsX2Vudg==
-			`), "\n"),
-			false,
+			"Multiple inputs",
+			args{"testdata/krm-function-input.yaml"},
+			wanted{[]string{
+				strings.TrimLeft(dedent.Dedent(`
+					apiVersion: v1
+					kind: Secret
+					metadata:
+					  name: secret-from-env
+					  annotations:
+					    config.k8s.io/id: "2"
+					data:
+					  VAR_ENV: dmFsX2Vudg==
+				`), "\n"),
+				strings.TrimLeft(dedent.Dedent(`
+					apiVersion: v1
+					kind: Secret
+					metadata:
+					  name: secret-from-file
+					  annotations:
+					    config.k8s.io/id: "1"
+					data:
+					  file.txt: c2VjcmV0Cg==
+				`), "\n"),
+			}, false},
 		},
 		{
-			"SecretFromFile",
-			args{"testdata/krm-function-input.yaml", 1},
-			strings.TrimLeft(dedent.Dedent(`
-				apiVersion: v1
-				kind: Secret
-				metadata:
-				  name: secret-from-file
-				  annotations:
-				    config.k8s.io/id: "1"
-				data:
-				  file.txt: c2VjcmV0Cg==
-			`), "\n"),
-			false,
+			"Single input",
+			args{"testdata/krm-combined.yaml"},
+			wanted{[]string{
+				strings.TrimLeft(dedent.Dedent(`
+					apiVersion: v1
+					kind: Secret
+					metadata:
+					  name: combined
+					  annotations:
+					    config.k8s.io/id: "1"
+					data:
+					  VAR_ENV: dmFsX2Vudg==
+					  file.txt: c2VjcmV0Cg==
+				`), "\n"),
+			}, false},
 		},
 	}
 	for _, tt := range tests {
@@ -108,14 +123,23 @@ func Test_GenerateKRMManifest(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				in, _ := ioutil.ReadFile(tt.args.rlFile)
 				out, err := fn.Run(fn.ResourceListProcessorFunc(generateKRMManifest), in)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("generateKRMManifest() error = %v, wantErr %v", err, tt.wantErr)
+				if (err != nil) != tt.want.err {
+					t.Errorf("generateKRMManifest() error = %v, want.err %v", err, tt.want.err)
+				}
+				if err != nil {
 					return
 				}
 				rl, _ := fn.ParseResourceList(out)
-				got := fmt.Sprint(rl.Items[tt.args.itemIndex])
-				if !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("generateKRMManifest() got = %v, want %v", got, tt.want)
+				got := rl.Items
+				if len(got) != len(tt.want.items) {
+					t.Errorf("generateKRMManifest()\ngot = %v\nwant = %v", got, tt.want.items)
+					return
+				}
+				for i, item := range tt.want.items {
+					want, _ := fn.ParseKubeObject([]byte(item))
+					if fmt.Sprintln(got[i]) != fmt.Sprintln(want) {
+						t.Errorf("generateKRMManifest()\ngot[%d] = %v\nwant = %v", i, got[i], want)
+					}
 				}
 			})
 		})

--- a/testdata/krm-combined.yaml
+++ b/testdata/krm-combined.yaml
@@ -1,0 +1,20 @@
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+metadata:
+  name: krm-function-input
+items:
+- apiVersion: goabout.com/v1beta1
+  kind: SopsSecretGenerator
+  metadata:
+    annotations:
+      config.kubernetes.io/function: |
+        exec:
+          path: SopsSecretGenerator
+      config.kubernetes.io/local-config: 'true'
+      config.k8s.io/id: '1'
+    name: combined
+  disableNameSuffixHash: true
+  files:
+    - testdata/file.txt
+  envs:
+    - testdata/vars.env

--- a/testdata/krm-error.yaml
+++ b/testdata/krm-error.yaml
@@ -1,0 +1,18 @@
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+metadata:
+  name: krm-function-input
+items:
+- apiVersion: goabout.com/v1beta1
+  kind: SoupSecretGenerator
+  metadata:
+    annotations:
+      config.kubernetes.io/function: |
+        exec:
+          path: SopsSecretGenerator
+      config.kubernetes.io/local-config: 'true'
+      config.k8s.io/id: '1'
+    name: secret-from-file
+  disableNameSuffixHash: true
+  files:
+    - testdata/file.txt


### PR DESCRIPTION
- Refactor krm tests
- Refactor a shared "decryptFile" function
- Use fn.KubeObjects instead of hand-rolled type
- Clean up krm error handling
- Introduce a unit test for KRM error handling
