### PR TITLE
New API: SopsSecretGenerator.objects

### DIFF
--- a/SopsSecretGenerator.go
+++ b/SopsSecretGenerator.go
@@ -193,8 +193,19 @@ func decryptExtraObjects(input SopsSecretGenerator) ([]string, error) {
 		if err != nil {
 			return result, err
 		}
-		// TODO: If the result is a multi-entry yaml, do we need to split it?
-		result = append(result, string(decrypted))
+		if formats.FormatForPath(file) == formats.Yaml {
+			// Process each interior yaml object separately
+			parts := bytes.Split(decrypted, []byte("\n---"))
+			for _, part := range parts {
+				part = bytes.TrimFunc(part, unicode.IsSpace)
+				// checking >2 accounts for empty buffers plus the null {} yaml document
+				if len(part) > 2 {
+					result = append(result, string(part))
+				}
+			}
+		} else {
+			result = append(result, string(decrypted))
+		}
 	}
 	return result, nil
 }

--- a/SopsSecretGenerator_test.go
+++ b/SopsSecretGenerator_test.go
@@ -78,7 +78,7 @@ func Test_GenerateKRMManifest(t *testing.T) {
 			"Multiple inputs",
 			args{"testdata/krm-function-input.yaml"},
 			wanted{[]string{
-				strings.TrimLeft(dedent.Dedent(`
+				strings.Trim(dedent.Dedent(`
 					apiVersion: v1
 					kind: ConfigMap
 					metadata:
@@ -115,7 +115,7 @@ func Test_GenerateKRMManifest(t *testing.T) {
 			"Single input",
 			args{"testdata/krm-combined.yaml"},
 			wanted{[]string{
-				strings.TrimLeft(dedent.Dedent(`
+				strings.Trim(dedent.Dedent(`
 					apiVersion: v1
 					kind: ConfigMap
 					metadata:
@@ -202,7 +202,7 @@ func Test_ProcessSopsSecretGenerator(t *testing.T) {
 			"Object Passthrough",
 			args{"testdata/generator-obj.yaml"},
 			[]string{
-				strings.TrimLeft(dedent.Dedent(`
+				strings.Trim(dedent.Dedent(`
 				    apiVersion: v1
 				    kind: ConfigMap
 				    metadata:
@@ -228,7 +228,7 @@ func Test_ProcessSopsSecretGenerator(t *testing.T) {
 				    data:
 				        file.txt: c2VjcmV0Cg==
 				`), "\n"),
-				strings.TrimLeft(dedent.Dedent(`
+				strings.Trim(dedent.Dedent(`
 				    apiVersion: v1
 				    kind: ConfigMap
 				    metadata:
@@ -763,6 +763,94 @@ func Test_decryptExtraObjects(t *testing.T) {
 		{
 			"Bad file path",
 			args{[]string{"testdata/no-such-file.yaml"}},
+			want{[]string{}, true},
+		},
+		{
+			"Multiple objects (data encryption)",
+			args{[]string{"testdata/obj-multi-encrypted.yaml"}},
+			want{[]string{
+				strings.Trim(dedent.Dedent(`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				    name: cfg
+				    labels:
+				        app: test
+				data:
+				    one: "1"
+				    two: "2"
+				`), "\n"),
+				strings.Trim(dedent.Dedent(`
+					apiVersion: v1
+					kind: Secret
+					metadata:
+					    name: secret
+					data:
+					    username: amFzbWluZQo=
+					    password: dFlnM3J0WWczcgo=
+				`), "\n"),
+			}, false},
+		},
+		{
+			"Multiple objects (all fields encrypted)",
+			args{[]string{"testdata/obj-multi-allfields.yaml"}},
+			want{[]string{
+				strings.Trim(dedent.Dedent(`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				    name: cfg
+				    labels:
+				        app: test
+				data:
+				    one: "1"
+				    two: "2"
+				`), "\n"),
+				strings.Trim(dedent.Dedent(`
+					apiVersion: v1
+					kind: Secret
+					metadata:
+					    name: secret
+					data:
+					    username: amFzbWluZQo=
+					    password: dFlnM3J0WWczcgo=
+				`), "\n"),
+			}, false},
+		},
+		{
+			"Multiple objects (with empty yaml sections)",
+			args{[]string{"testdata/obj-multi-emptydocs.yaml"}},
+			want{[]string{
+				strings.Trim(dedent.Dedent(`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				    name: cfg
+				    labels:
+				        app: test
+				data:
+				    one: "1"
+				    two: "2"
+				`), "\n"),
+				strings.Trim(dedent.Dedent(`
+					apiVersion: v1
+					kind: Secret
+					metadata:
+					    name: secret
+					data:
+					    username: amFzbWluZQo=
+					    password: dFlnM3J0WWczcgo=
+				`), "\n"),
+			}, false},
+		},
+		{
+			"Multiple objects (one not encrypted)",
+			args{[]string{"testdata/obj-multi-partial.yaml"}},
+			want{[]string{}, true},
+		},
+		{
+			"Multiple objects (not encrypted)",
+			args{[]string{"testdata/obj-multi-unencrypted.yaml"}},
 			want{[]string{}, true},
 		},
 	}

--- a/testdata/generator-all.yaml
+++ b/testdata/generator-all.yaml
@@ -1,0 +1,9 @@
+apiVersion: goabout.com/v1beta1
+kind: SopsSecretGenerator
+metadata:
+  name: secret
+disableNameSuffixHash: true
+files:
+  - testdata/file.txt
+objects:
+  - testdata/obj-encrypted.yaml

--- a/testdata/generator-obj.yaml
+++ b/testdata/generator-obj.yaml
@@ -1,0 +1,7 @@
+apiVersion: goabout.com/v1beta1
+kind: SopsSecretGenerator
+metadata:
+  name: secret
+disableNameSuffixHash: true
+objects:
+  - testdata/obj-encrypted.yaml

--- a/testdata/krm-combined.yaml
+++ b/testdata/krm-combined.yaml
@@ -18,3 +18,5 @@ items:
     - testdata/file.txt
   envs:
     - testdata/vars.env
+  objects:
+    - testdata/obj-encrypted.yaml

--- a/testdata/krm-function-input.yaml
+++ b/testdata/krm-function-input.yaml
@@ -29,3 +29,15 @@ items:
   disableNameSuffixHash: true
   envs:
     - testdata/vars.env
+- apiVersion: goabout.com/v1beta1
+  kind: SopsSecretGenerator
+  metadata:
+    annotations:
+      config.kubernetes.io/function: |
+        exec:
+          path: SopsSecretGenerator
+      config.kubernetes.io/local-config: 'true'
+      config.k8s.io/id: '3'
+    name: arbitrary-obj
+  objects:
+    - testdata/obj-encrypted.yaml

--- a/testdata/obj-allfields.yaml
+++ b/testdata/obj-allfields.yaml
@@ -1,0 +1,35 @@
+apiVersion: ENC[AES256_GCM,data:rAs=,iv:V48stquv6J0vCU+VbJArb31HFRTVpovvXrJYdQ4iZJ8=,tag:5sAzkiaublBE1oLqmF/7qg==,type:str]
+kind: ENC[AES256_GCM,data:RSyWjuvQIlMj,iv:GX4f4kXXXnQfsToV+afK9TZqMC2/pWaPvcSUHDIaLlY=,tag:y6mSFonKPnt6DHTcLEYOGA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:pjRn,iv:F42GW047YzuDiXjedNuIPHCSBl+q+hz+eoIncpRenMY=,tag:TLJrl+822op+G93DkODDAg==,type:str]
+    labels:
+        app: ENC[AES256_GCM,data:f/djSw==,iv:ktXRzzPRun/tbqjmgpTg/Q9r9t/1HD3rZ/RhSB+2raY=,tag:QYPbQn8N/0jmffe31pH4QA==,type:str]
+data:
+    one: ENC[AES256_GCM,data:kQ==,iv:SetZkSb08Dj1yc0VrN0aC9TQDNiEbX/CjpND52HqeBU=,tag:kJHmTN56hDYsRl60qvNOcQ==,type:str]
+    two: ENC[AES256_GCM,data:qA==,iv:/17uBjiWVOfvjbk1MW07TDsXEgtQL/OcQBms8agUH8U=,tag:mC56ibnBE68ebA3HIqByog==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T00:14:04Z"
+    mac: ENC[AES256_GCM,data:eqz7Bx95yVZAGnJ0oFbaZqjmKP9IEczzPGDFLunT5IracA6Iq9pRWW6wXE9iba+Ql2INQi/BG75qCC74t9GlkqPMv3amcGC2ZgR2HqaLFkQnkSrgUF+qL3sEI6/vZMfZfyubJvxdqtEb5hYnbqGDJ73wfNE+6kJrpj2Xz9bmvJI=,iv:yDPmUxSh8TCVuc5hub4mrylmt6eKZGld5j/bcXGXWHE=,tag:DB0WugM/6fgkcQFJCJR0yQ==,type:str]
+    pgp:
+        - created_at: "2022-09-22T00:14:04Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf/W3DdECTUe+WoNm8ecn6EKaKfvpnMVALUTroxmYYIl2T+
+            ZulTxe2VCjORcLzY8POQ//2XLnBtUJi2fl7Ks2XH/aaP9uVX+ITtIA5cvV5ZUQ/S
+            Hrc+92KeHbM26h7T3jGSIEp+5MV8oyiilpmgrT4EZqtGmN2LJwR9jv31bk2wd8Bv
+            UvkT1y5f81ueMMmviwBbegCGNiOHqplorUwOvOD/I1eTGze47YcSDWvzkdttSlf/
+            Yyo9hrpujm0TedF1hOyuOw7BAghQFc3YorSDfBzRZ2JnsXXCzG3o5MYihdfVewNQ
+            O0NphwmtiBlhkrorBYlU1tCJD8W6PGb5EEyFU1V0xdJcAUpi0zz3MXGGB/I7NyTu
+            q+vS6b3jymaIssipda4CFXMzTNOR3DrdVguYrgeVhhgDE3Qqai/1D14wyM/T8+H0
+            yHoc5Em7k+oACIOv7kX/3nQmMipYBOj2oDI/M2s=
+            =H+jG
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/testdata/obj-encrypted.yaml
+++ b/testdata/obj-encrypted.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cfg
+    labels:
+        app: test
+data:
+    one: ENC[AES256_GCM,data:kQ==,iv:uY++Lb9Zpsv71DxAghvYSr3pCUlRTl20rzSCIlWRVwk=,tag:Fn2upysSBuN6guDmk+o6hw==,type:str]
+    two: ENC[AES256_GCM,data:Aw==,iv:xArvhe+CAtKlM62HDHTGJpRko7hFREbCzRgnJzGhXuw=,tag:OaLSCBQfkw4mportyvwMiQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:15:50Z"
+    mac: ENC[AES256_GCM,data:UJw5OHqx5yzWdPrJeTufCn9YP91zgEulirrnHg3pEPlTOwlsYlgnToOmsBMBUxiWl5cotaRLtOYL14r84659bw4Yu290H7hqWV1c86XbnXiH0AOmj8lQZabsRamKQ5wS59oZ+pdbRtrd+wrSZeBopUE3J1UKI3nPWBHy16Br01U=,iv:l9oRiszFbkUo14W/To1d8tsfWpKNlbrliDeDE9AVMts=,tag:t7YSBAqzpaxe+BWKxTRpMQ==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:15:49Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf9EtynBgsztEPhVBkjRZ9huZDusjprSyvsNcpy8fwMKL1d
+            ENVLXBTEwaw64GR6q3JNFEoIcigGQEHd9lZEYq23Fm5BDGdOjrGOuozHTK4e2ueX
+            eqqITcpU58OiYymFFnYA1S+VsBgc3ag2TsU9rvx8wGzKedeqOXPt6aMs0AjUpusQ
+            hZ4JnNhbzk+LMv7PgUBOLMaS92O8zb6EiQLe7gzaDHtZ0pW0cY7N2n21bK9pzHva
+            DA4mzOwU29N3eBUumvIE7iitZhcSH6SCRXZ3ax0EGG+bUsebMRoILL5qWHqthTfS
+            GRtrLpZys5q9K2Q7mvIDCcvwh8XJ9i52Ma7hdIAaKtJeATWqM8nuqoeX4eWXHHta
+            uSDz2Y4OWrS0Lba3B00bZUeqHJeftbiviGc8oGFQBHfoTQszJ/At3NLU++/6Vwdl
+            NtHfXVnb7SeJpQOR1t9HPr6L92H4u/5uX8IFegGZbA==
+            =oy6A
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    encrypted_regex: ^data$
+    version: 3.7.3

--- a/testdata/obj-multi-allfields.yaml
+++ b/testdata/obj-multi-allfields.yaml
@@ -1,0 +1,69 @@
+apiVersion: ENC[AES256_GCM,data:3kU=,iv:9pul3/VFhdPZUSPTUeTjWPgpLwSKn6i/uJ0dPK7kWyU=,tag:PXUxiu3RLL4e1yYxaLGSHA==,type:str]
+kind: ENC[AES256_GCM,data:z520L05B2agn,iv:m7O91UWbFqDZbsT9d+kJaS5KiHyji+aAe3zCNshYWrQ=,tag:eM3RGni9Wqk2T63vciJbeQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:fB59,iv:zOZ2qffVYkgZ4oOFGPNdZX+/0RWE/Ruldnmy8Sg/ZTo=,tag:6lsC3cYYbWER+WzHW+upRQ==,type:str]
+    labels:
+        app: ENC[AES256_GCM,data:iQ/YGw==,iv:n0pwfVnimCu4JcePlU0XqiVyqMINFXfNHNuUNW61igs=,tag:SCa2dFMQ2Dn1S8uKuscWmA==,type:str]
+data:
+    one: ENC[AES256_GCM,data:Qg==,iv:5G9LlKJ7GJQBOETG+p2wIiINAFVMJ4YN4DnvXtFnLvY=,tag:27ViXaJtZiTU8TFFNqtxQA==,type:str]
+    two: ENC[AES256_GCM,data:sA==,iv:lMNdPXrFKjtufy8WYuPu6rxxHFB38gvM8p1asAL32ZY=,tag:6OLj+arLeuDzKELhRV7O0A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:45:01Z"
+    mac: ENC[AES256_GCM,data:b1F8qVK9P8hwS55QKHqIgS2ASTTqY/WXSdcoRUyGzcgJmUV3ymRQ7ffiyC0NxkkXjgVxYCInPGRKzmRlXixy0HwIW7sepKuEBGm0CVbGUvou4p+D9C+1z18piX+8SG4etHlkY1bjuIX7KZICHV8GLGES8d42OGimhQbZLoM151Y=,iv:IzB2iCVj3UCwV5OW+DzqMAL/MOJI2IO3Lp63AaY0ecw=,tag:A11QuBryEIi69wzuGHYZFA==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:45:01Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf+JY2HwUeeNzGWX0bJzBGfYUpd6om37HJSb0bquct/Ko9n
+            TpnrBl3fZgs7uEkFdBqj4dlM6jNoFZeNuw3Y4AJM/5/ypEjfuRy+XZrRV4a21eHY
+            5pff5371XpuigJifctacIQz29M7d9ZqJ53Pritcd1sTtBy8T+sOQAu8LtdVFjXqj
+            tIpuZGfMtfL1K3X8Cr3Rmt3w0sk/1C7lHrNcuG2636hjMfZiKFJKueFO/lqDQNPO
+            04x2Cs402p3TeHqgCJZU7b0KbT66nPnPRMHaZfkV+QqEMHH1+9koagR/knUxqAUc
+            g1GasIdCShp/2JvocnmMRmv44ZvjRaVlMTwGVUinQtJeARv1vhxXsSV4ferECLKz
+            q9JacWWGuFwqG8pVr6cF+s1JZbYJOK7l00Yz8nIGnG5Pxx42StcnSNlEO1LmYbt4
+            9j7hVwklQl0/wUd7eJ+aesm0Q+MBG4AXrjvjkn78UA==
+            =RvwS
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3
+---
+apiVersion: ENC[AES256_GCM,data:jDY=,iv:x2vRA2+5OqbA1YfJwhE9b5e91G/xM5IIUyknaqpB49w=,tag:E6fwXtz1kD+nJ3TfX2Louw==,type:str]
+kind: ENC[AES256_GCM,data:LDIqHSy3,iv:c7tfo8/NtMEPuWUFGjIzqVzhQntQPm26Dtk7970KmhI=,tag:lrNww/DP/MR2W1dmHG41Jg==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:ukRU05DM,iv:gUXwACsQ+fA352I813HAK1/JPmWHVMjbPza3JncjH3U=,tag:4M1NLZLdIOoueY3B6k7F0w==,type:str]
+data:
+    username: ENC[AES256_GCM,data:eT4TWRyyZfGltao4,iv:bBIoIOv9mL55GyUhGtd8RPPMcbNMZZEegZ53O7ZpTLE=,tag:NbSnZ4RJnbWvF2yrcIZK8Q==,type:str]
+    password: ENC[AES256_GCM,data:OjnHWDD48nGQAhsfC1ei2w==,iv:uiQprrbOjBpAhl29XCKRI/1g0Hicdp4O33rBKP/zEnY=,tag:NKQ8n3+PRRuwaiKJrybnsg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:45:01Z"
+    mac: ENC[AES256_GCM,data:b1F8qVK9P8hwS55QKHqIgS2ASTTqY/WXSdcoRUyGzcgJmUV3ymRQ7ffiyC0NxkkXjgVxYCInPGRKzmRlXixy0HwIW7sepKuEBGm0CVbGUvou4p+D9C+1z18piX+8SG4etHlkY1bjuIX7KZICHV8GLGES8d42OGimhQbZLoM151Y=,iv:IzB2iCVj3UCwV5OW+DzqMAL/MOJI2IO3Lp63AaY0ecw=,tag:A11QuBryEIi69wzuGHYZFA==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:45:01Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf+JY2HwUeeNzGWX0bJzBGfYUpd6om37HJSb0bquct/Ko9n
+            TpnrBl3fZgs7uEkFdBqj4dlM6jNoFZeNuw3Y4AJM/5/ypEjfuRy+XZrRV4a21eHY
+            5pff5371XpuigJifctacIQz29M7d9ZqJ53Pritcd1sTtBy8T+sOQAu8LtdVFjXqj
+            tIpuZGfMtfL1K3X8Cr3Rmt3w0sk/1C7lHrNcuG2636hjMfZiKFJKueFO/lqDQNPO
+            04x2Cs402p3TeHqgCJZU7b0KbT66nPnPRMHaZfkV+QqEMHH1+9koagR/knUxqAUc
+            g1GasIdCShp/2JvocnmMRmv44ZvjRaVlMTwGVUinQtJeARv1vhxXsSV4ferECLKz
+            q9JacWWGuFwqG8pVr6cF+s1JZbYJOK7l00Yz8nIGnG5Pxx42StcnSNlEO1LmYbt4
+            9j7hVwklQl0/wUd7eJ+aesm0Q+MBG4AXrjvjkn78UA==
+            =RvwS
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/testdata/obj-multi-emptydocs.yaml
+++ b/testdata/obj-multi-emptydocs.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cfg
+    labels:
+        app: test
+data:
+    one: ENC[AES256_GCM,data:Lg==,iv:t7hkFKAnZehQyMFIXHJrcAX5c/IaSJkhccRZ/HPB3zw=,tag:fNr3YNRCJrsiA4OVdmY7hg==,type:str]
+    two: ENC[AES256_GCM,data:5g==,iv:ddTJurcxJQPMF3fxxtjg5sSWQ8HmQQqu4XS9F5BGYHY=,tag:6B4AM4Bf9JAQJ5O0ZCf33A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:46:31Z"
+    mac: ENC[AES256_GCM,data:afztjySyuPtYHSI/jlG8OQwWN6U2NR4qTiD2aGuWsJ/sGwo1SxvLPm5+ku3q+20Z/4yHumeDmSyHRhRp4wMOjjdfqGK0ZYqOqtpH6VDdb9dMaPpTMpYk0P+9IZMqM+FubOXLsDKjzvoYjvKcHyntUgkECVKeCFgHj8bxDquK0Rg=,iv:bQG+vsq1Avn/zaNIsJ6D+ADkVPyY9wU2CJXsnrKxgYY=,tag:K8mNIG8lP7xO+rHuAd242g==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:46:31Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf+KyycdXkTAb52GoHBLsym1ONZtyLDz+SgtRhrvmM1lUHG
+            DN9sz5bYYyxX/Q49BwddDPPzkqdcRVVZOfRy4mbTFmScCesSD/VP5uo0p+q2NIhH
+            tJFTezbuzPB0HboCKfCOYXcfXNmLqm4EHbOy+hjjpSXs9eSnYn8vT6X7uYfeaLKb
+            Z6Lln6+qTjJ72H+CvmTxYzjHTCChvHvUi0nSBsgYOgzb8/cAntdcOadVCKYqLkdJ
+            8BrmZQqSMiP7Us1492glKXQ2kLpShT/m/pZU2kLCpOiRchSUqaqLkr1Jt84++ewa
+            vQ0AR6pPF5+AfDolGocukGx4wF9NrHyuwQC/2QcGKtJcAbVmKa5QG/GCsE1hAJK3
+            0BDb9udMlw1rrgZReZQZHMgICAk11OSk7xlx9q4z4YUcChJLbVhlgfmuKkdXQxJ6
+            Opqib5Aq2vqQirWK1AbA1rkr3JtyTZ/TvTL/Qgg=
+            =mM06
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    encrypted_regex: ^data$
+    version: 3.7.3
+---
+
+---
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: secret
+data:
+    username: ENC[AES256_GCM,data:VJFrFe1q7MX51m9D,iv:duD7OD/6f6FniTzcolnVeskOCTXUXJ4ZE9bA36hZMtc=,tag:xKaarLbpMAE45AZBpEdKNQ==,type:str]
+    password: ENC[AES256_GCM,data:E8cBaGOBTZ1984jFwPEfEw==,iv:RrogeHD8fjCpjxdSk3pzkV+3PMGwqaxaXjl0via3oYs=,tag:UTD33PaKZ9TSPAIT99dv0Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:46:31Z"
+    mac: ENC[AES256_GCM,data:afztjySyuPtYHSI/jlG8OQwWN6U2NR4qTiD2aGuWsJ/sGwo1SxvLPm5+ku3q+20Z/4yHumeDmSyHRhRp4wMOjjdfqGK0ZYqOqtpH6VDdb9dMaPpTMpYk0P+9IZMqM+FubOXLsDKjzvoYjvKcHyntUgkECVKeCFgHj8bxDquK0Rg=,iv:bQG+vsq1Avn/zaNIsJ6D+ADkVPyY9wU2CJXsnrKxgYY=,tag:K8mNIG8lP7xO+rHuAd242g==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:46:31Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf+KyycdXkTAb52GoHBLsym1ONZtyLDz+SgtRhrvmM1lUHG
+            DN9sz5bYYyxX/Q49BwddDPPzkqdcRVVZOfRy4mbTFmScCesSD/VP5uo0p+q2NIhH
+            tJFTezbuzPB0HboCKfCOYXcfXNmLqm4EHbOy+hjjpSXs9eSnYn8vT6X7uYfeaLKb
+            Z6Lln6+qTjJ72H+CvmTxYzjHTCChvHvUi0nSBsgYOgzb8/cAntdcOadVCKYqLkdJ
+            8BrmZQqSMiP7Us1492glKXQ2kLpShT/m/pZU2kLCpOiRchSUqaqLkr1Jt84++ewa
+            vQ0AR6pPF5+AfDolGocukGx4wF9NrHyuwQC/2QcGKtJcAbVmKa5QG/GCsE1hAJK3
+            0BDb9udMlw1rrgZReZQZHMgICAk11OSk7xlx9q4z4YUcChJLbVhlgfmuKkdXQxJ6
+            Opqib5Aq2vqQirWK1AbA1rkr3JtyTZ/TvTL/Qgg=
+            =mM06
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    encrypted_regex: ^data$
+    version: 3.7.3

--- a/testdata/obj-multi-encrypted.yaml
+++ b/testdata/obj-multi-encrypted.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cfg
+    labels:
+        app: test
+data:
+    one: ENC[AES256_GCM,data:Lg==,iv:t7hkFKAnZehQyMFIXHJrcAX5c/IaSJkhccRZ/HPB3zw=,tag:fNr3YNRCJrsiA4OVdmY7hg==,type:str]
+    two: ENC[AES256_GCM,data:5g==,iv:ddTJurcxJQPMF3fxxtjg5sSWQ8HmQQqu4XS9F5BGYHY=,tag:6B4AM4Bf9JAQJ5O0ZCf33A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:46:31Z"
+    mac: ENC[AES256_GCM,data:afztjySyuPtYHSI/jlG8OQwWN6U2NR4qTiD2aGuWsJ/sGwo1SxvLPm5+ku3q+20Z/4yHumeDmSyHRhRp4wMOjjdfqGK0ZYqOqtpH6VDdb9dMaPpTMpYk0P+9IZMqM+FubOXLsDKjzvoYjvKcHyntUgkECVKeCFgHj8bxDquK0Rg=,iv:bQG+vsq1Avn/zaNIsJ6D+ADkVPyY9wU2CJXsnrKxgYY=,tag:K8mNIG8lP7xO+rHuAd242g==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:46:31Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf+KyycdXkTAb52GoHBLsym1ONZtyLDz+SgtRhrvmM1lUHG
+            DN9sz5bYYyxX/Q49BwddDPPzkqdcRVVZOfRy4mbTFmScCesSD/VP5uo0p+q2NIhH
+            tJFTezbuzPB0HboCKfCOYXcfXNmLqm4EHbOy+hjjpSXs9eSnYn8vT6X7uYfeaLKb
+            Z6Lln6+qTjJ72H+CvmTxYzjHTCChvHvUi0nSBsgYOgzb8/cAntdcOadVCKYqLkdJ
+            8BrmZQqSMiP7Us1492glKXQ2kLpShT/m/pZU2kLCpOiRchSUqaqLkr1Jt84++ewa
+            vQ0AR6pPF5+AfDolGocukGx4wF9NrHyuwQC/2QcGKtJcAbVmKa5QG/GCsE1hAJK3
+            0BDb9udMlw1rrgZReZQZHMgICAk11OSk7xlx9q4z4YUcChJLbVhlgfmuKkdXQxJ6
+            Opqib5Aq2vqQirWK1AbA1rkr3JtyTZ/TvTL/Qgg=
+            =mM06
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    encrypted_regex: ^data$
+    version: 3.7.3
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: secret
+data:
+    username: ENC[AES256_GCM,data:VJFrFe1q7MX51m9D,iv:duD7OD/6f6FniTzcolnVeskOCTXUXJ4ZE9bA36hZMtc=,tag:xKaarLbpMAE45AZBpEdKNQ==,type:str]
+    password: ENC[AES256_GCM,data:E8cBaGOBTZ1984jFwPEfEw==,iv:RrogeHD8fjCpjxdSk3pzkV+3PMGwqaxaXjl0via3oYs=,tag:UTD33PaKZ9TSPAIT99dv0Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:46:31Z"
+    mac: ENC[AES256_GCM,data:afztjySyuPtYHSI/jlG8OQwWN6U2NR4qTiD2aGuWsJ/sGwo1SxvLPm5+ku3q+20Z/4yHumeDmSyHRhRp4wMOjjdfqGK0ZYqOqtpH6VDdb9dMaPpTMpYk0P+9IZMqM+FubOXLsDKjzvoYjvKcHyntUgkECVKeCFgHj8bxDquK0Rg=,iv:bQG+vsq1Avn/zaNIsJ6D+ADkVPyY9wU2CJXsnrKxgYY=,tag:K8mNIG8lP7xO+rHuAd242g==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:46:31Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf+KyycdXkTAb52GoHBLsym1ONZtyLDz+SgtRhrvmM1lUHG
+            DN9sz5bYYyxX/Q49BwddDPPzkqdcRVVZOfRy4mbTFmScCesSD/VP5uo0p+q2NIhH
+            tJFTezbuzPB0HboCKfCOYXcfXNmLqm4EHbOy+hjjpSXs9eSnYn8vT6X7uYfeaLKb
+            Z6Lln6+qTjJ72H+CvmTxYzjHTCChvHvUi0nSBsgYOgzb8/cAntdcOadVCKYqLkdJ
+            8BrmZQqSMiP7Us1492glKXQ2kLpShT/m/pZU2kLCpOiRchSUqaqLkr1Jt84++ewa
+            vQ0AR6pPF5+AfDolGocukGx4wF9NrHyuwQC/2QcGKtJcAbVmKa5QG/GCsE1hAJK3
+            0BDb9udMlw1rrgZReZQZHMgICAk11OSk7xlx9q4z4YUcChJLbVhlgfmuKkdXQxJ6
+            Opqib5Aq2vqQirWK1AbA1rkr3JtyTZ/TvTL/Qgg=
+            =mM06
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    encrypted_regex: ^data$
+    version: 3.7.3

--- a/testdata/obj-multi-partial.yaml
+++ b/testdata/obj-multi-partial.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cfg
+    labels:
+        app: test
+data:
+    one: "1"
+    two: "2"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: secret
+data:
+    username: ENC[AES256_GCM,data:VJFrFe1q7MX51m9D,iv:duD7OD/6f6FniTzcolnVeskOCTXUXJ4ZE9bA36hZMtc=,tag:xKaarLbpMAE45AZBpEdKNQ==,type:str]
+    password: ENC[AES256_GCM,data:E8cBaGOBTZ1984jFwPEfEw==,iv:RrogeHD8fjCpjxdSk3pzkV+3PMGwqaxaXjl0via3oYs=,tag:UTD33PaKZ9TSPAIT99dv0Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-09-22T08:46:31Z"
+    mac: ENC[AES256_GCM,data:afztjySyuPtYHSI/jlG8OQwWN6U2NR4qTiD2aGuWsJ/sGwo1SxvLPm5+ku3q+20Z/4yHumeDmSyHRhRp4wMOjjdfqGK0ZYqOqtpH6VDdb9dMaPpTMpYk0P+9IZMqM+FubOXLsDKjzvoYjvKcHyntUgkECVKeCFgHj8bxDquK0Rg=,iv:bQG+vsq1Avn/zaNIsJ6D+ADkVPyY9wU2CJXsnrKxgYY=,tag:K8mNIG8lP7xO+rHuAd242g==,type:str]
+    pgp:
+        - created_at: "2022-09-22T08:46:31Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA6z+tHR/duVIAQf+KyycdXkTAb52GoHBLsym1ONZtyLDz+SgtRhrvmM1lUHG
+            DN9sz5bYYyxX/Q49BwddDPPzkqdcRVVZOfRy4mbTFmScCesSD/VP5uo0p+q2NIhH
+            tJFTezbuzPB0HboCKfCOYXcfXNmLqm4EHbOy+hjjpSXs9eSnYn8vT6X7uYfeaLKb
+            Z6Lln6+qTjJ72H+CvmTxYzjHTCChvHvUi0nSBsgYOgzb8/cAntdcOadVCKYqLkdJ
+            8BrmZQqSMiP7Us1492glKXQ2kLpShT/m/pZU2kLCpOiRchSUqaqLkr1Jt84++ewa
+            vQ0AR6pPF5+AfDolGocukGx4wF9NrHyuwQC/2QcGKtJcAbVmKa5QG/GCsE1hAJK3
+            0BDb9udMlw1rrgZReZQZHMgICAk11OSk7xlx9q4z4YUcChJLbVhlgfmuKkdXQxJ6
+            Opqib5Aq2vqQirWK1AbA1rkr3JtyTZ/TvTL/Qgg=
+            =mM06
+            -----END PGP MESSAGE-----
+          fp: 2D2483DF73A3A0FAEE3C2A695BDC395360CE8FF4
+    encrypted_regex: ^data$
+    version: 3.7.3

--- a/testdata/obj-multi-unencrypted.yaml
+++ b/testdata/obj-multi-unencrypted.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cfg
+    labels:
+        app: test
+data:
+    one: "1"
+    two: "2"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: secret
+data:
+    username: amFzbWluZQo=
+    password: dFlnM3J0WWczcgo=

--- a/testdata/obj-unencrypted.yaml
+++ b/testdata/obj-unencrypted.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cfg
+    labels:
+        app: test
+data:
+    one: "1"
+    two: "2"


### PR DESCRIPTION
Here's a quick overview of a new API addition I think I'd find useful.

## Problem
What if a simple Secret generator isn't enough. What if I want to decrypt an encrypted ConfigMap or other non-sevret objects?

## Solution
SopsSecretGenerator is well-poised to do just that! in addition to decrypting env files or entire files as secret contents, why not add a facility to take whole sops-encrypted objects and just decrypt them?

```yaml
apiVersion: goabout.com/v1beta1
kind: SopsSecretGenerator
metadata:
  name: secret
objects:
  - testdata/obj-encrypted.yaml
```

When invoked as a legacy plugin we can concatenate multiple yaml files with `---`, and in KRM mode we can just add more items, beside (or instead of) the secret we would normally generate.

## Approach
Split into 3 commit steps:
- Introduce SopsSecretGenerator.objects API
- Fix support for multi-object yaml object passthrough
- Document SopsSecretGenerator.objects API
