### PR TITLE
Bypass SOPS by adding dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ metadata:
 
 ### SOPS Dry Run Mode
 
-You can bypass the SOPS description process if you lack access to your keys and simply wish to ensure that the kustomize command executes correctly (can be useful for CI).
+You can bypass the SOPS decryption process if you lack access to your keys and simply wish to ensure that the kustomize command executes correctly (can be useful for CI).
 
 set SOPS_DRY_RUN env variable before running kustomize command as follow:
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ metadata:
 
 ### SOPS Dry Run Mode
 
-You can skip SOPS descyption process when you don't have an access to your keys and you just want to verify that kustomize command runs properly:
+You can bypass the SOPS description process if you lack access to your keys and simply wish to ensure that the kustomize command executes correctly (can be useful for CI).
 
 set SOPS_DRY_RUN env variable before running kustomize command as follow:
 

--- a/README.md
+++ b/README.md
@@ -104,20 +104,20 @@ metadata:
 
 You can skip SOPS descyption process when you don't have an access to your keys and you just want to verify that kustomize command runs properly:
 
-set SOPS_DRY_RUN env variable before running kustomize command.
+set SOPS_DRY_RUN env variable before running kustomize command as follow:
 
 ```bash
 export SOPS_DRY_RUN=true
 kustomize build --enable-alpha-plugins --enable-exec
 ```
 
-The output is a Kubernetes secret containing the decrypted data with a placeholder value encrypted in base64:
+The output is a Kubernetes secret containing the decrypted data with a placeholder value SOPS_ENCRYPTED_DATA_OMITTED:
 
 ```yaml
 apiVersion: v1
 data:
-  FOO: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
-  secret-file.txt: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
+  FOO: SOPS_ENCRYPTED_DATA_OMITTED
+  secret-file.txt: SOPS_ENCRYPTED_DATA_OMITTED
 kind: Secret
 metadata:
   name: my-secret-6d2fchb89d

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 SecretGenerator ❤ sops
 
-
 ## Why use this?
 
 [Kustomize](https://github.com/kubernetes-sigs/kustomize) is a great tool for implementing a [GitOps](https://www.weave.works/blog/gitops-operations-by-pull-request) workflow. When a repository describes the entire system state, it often contains secrets that need to be encrypted at rest. Mozilla's [sops](https://github.com/mozilla/sops) is a simple and flexible tool that is very suitable for that task.
@@ -19,9 +18,7 @@ Since version 1.5.0, the plugin can be used as a [KRM Function](https://github.c
 
 Credit goes to [Seth Pollack](https://github.com/sethpollack) for the [Kustomize Secret Generator Plugins KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/kustomize-secret-generator-plugins.md) and subsequent implementation that made this possible.
 
-
 ## Installation
-
 
 SopsSecretGenerator is available as a binary, or as a Docker image.
 
@@ -30,6 +27,7 @@ SopsSecretGenerator is available as a binary, or as a Docker image.
 Download the `SopsSecretGenerator` binary for your platform from the [GitHub releases page](https://github.com/goabout/kustomize-sopssecretgenerator/releases) and make it executable.
 
 For example, to install version 1.6.0 on Linux:
+
 ```bash
 VERSION=1.6.0 PLATFORM=linux ARCH=amd64
 curl -Lo SopsSecretGenerator "https://github.com/goabout/kustomize-sopssecretgenerator/releases/download/v${VERSION}/SopsSecretGenerator_${VERSION}_${PLATFORM}_${ARCH}"
@@ -38,15 +36,14 @@ chmod +x SopsSecretGenerator
 
 You do not need to install the `sops` binary for the plugin to work. The plugin includes and calls sops internally.
 
-
 ### Docker image
 
 See the [goabout/kustomize-sopssecretgenerator](https://hub.docker.com/repository/docker/goabout/kustomize-sopssecretgenerator) image at Docker Hub.
 
-
 ## Usage
 
 Create some encrypted values using `sops`:
+
 ```bash
 echo FOO=secret >secret-vars.env
 sops -e -i secret-vars.env
@@ -55,12 +52,12 @@ echo secret >secret-file.txt
 sops -e -i secret-file.txt
 ```
 
-
 ### Exec KRM Function
 
 Although the generator can run in a Docker container, any real usage requires to access to local resources such as the filesystem or a PGP socket. This example calls the binary directly.
 
 Add a generator to your kustomization:
+
 ```bash
 cat <<. >kustomization.yaml
 generators:
@@ -90,8 +87,9 @@ Run `kustomize build` with the `--enable-alpha-plugins` and `--enable-exec` flag
 ```bash
 kustomize build --enable-alpha-plugins --enable-exec
 ```
-    
+
 The output is a Kubernetes secret containing the decrypted data:
+
 ```yaml
 apiVersion: v1
 data:
@@ -102,16 +100,40 @@ metadata:
   name: my-secret-6d2fchb89d
 ```
 
+### SOPS Dry Run Mode
+
+You can skip SOPS descyption process when you don't have an access to your keys and you just want to verify that kustomize command runs properly:
+
+set SOPS_DRY_RUN env variable before running kustomize command.
+
+```bash
+export SOPS_DRY_RUN=true
+kustomize build --enable-alpha-plugins --enable-exec
+```
+
+The output is a Kubernetes secret containing the decrypted data with a placeholder value encrypted in base64:
+
+```yaml
+apiVersion: v1
+data:
+  FOO: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
+  secret-file.txt: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
+kind: Secret
+metadata:
+  name: my-secret-6d2fchb89d
+```
 
 ### Legacy Plugin
 
 First, install the plugin to `$XDG_CONFIG_HOME`: (By default, `$XDG_CONFIG_HOME` points to `$HOME/.config` on Linux and OS X, and `%LOCALAPPDATA%` on Windows.)
+
 ```bash
 mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/kustomize/plugin/goabout.com/v1beta1/sopssecretgenerator"
 mv SopsSecretGenerator "${XDG_CONFIG_HOME:-$HOME/.config}/kustomize/plugin/goabout.com/v1beta1/sopssecretgenerator"
 ```
 
 Add a generator to your kustomization:
+
 ```bash
 cat <<. >kustomization.yaml
 generators:
@@ -129,7 +151,6 @@ files:
   - secret-file.txt
 .
 ```
-
 
 ### Generator Options
 
@@ -157,37 +178,33 @@ An example showing all options:
       - secret-file2.txt=secret-file2.sops.txt
     type: Opaque
 
-
 ## Using SopsSecretsGenerator with ArgoCD
 
 SopsSecretGenerator can be added to ArgoCD by [patching](./docs/argocd.md) an initContainer into the ArgoCD provided `install.yaml`.
-
 
 ## Alternatives
 
 There are a number of other plugins that can serve the same function:
 
-* [viaduct-ai/kustomize-sops](https://github.com/viaduct-ai/kustomize-sops)
-* [Agilicus/kustomize-sops](https://github.com/Agilicus/kustomize-sops)
-* [barlik/kustomize-sops](https://github.com/barlik/kustomize-sops)
-* [monopole/sopsencodedsecrets](https://github.com/monopole/sopsencodedsecrets)
-* [omninonsense/kustomize-sopsgenerator](https://github.com/omninonsense/kustomize-sopsgenerator)
-* [whatever-company/secretgen](https://github.com/whatever-company/secretgen)
+- [viaduct-ai/kustomize-sops](https://github.com/viaduct-ai/kustomize-sops)
+- [Agilicus/kustomize-sops](https://github.com/Agilicus/kustomize-sops)
+- [barlik/kustomize-sops](https://github.com/barlik/kustomize-sops)
+- [monopole/sopsencodedsecrets](https://github.com/monopole/sopsencodedsecrets)
+- [omninonsense/kustomize-sopsgenerator](https://github.com/omninonsense/kustomize-sopsgenerator)
+- [whatever-company/secretgen](https://github.com/whatever-company/secretgen)
 
 Additionally, there are other ways to use sops-encrypted secrets in Kubernetes:
 
-* [isindir/sops-secrets-operator](https://github.com/isindir/sops-secrets-operator)
-* [craftypath/sops-operator](https://github.com/craftypath/sops-operator)
-* [jkroepke/helm-secrets](https://github.com/jkroepke/helm-secrets)
-* [dschniepp/sealit](https://github.com/dschniepp/sealit)
+- [isindir/sops-secrets-operator](https://github.com/isindir/sops-secrets-operator)
+- [craftypath/sops-operator](https://github.com/craftypath/sops-operator)
+- [jkroepke/helm-secrets](https://github.com/jkroepke/helm-secrets)
+- [dschniepp/sealit](https://github.com/dschniepp/sealit)
 
 Most of these projects are in constant development. I invite you to check them out and pick the project that best fits your goals.
-
 
 ## Development
 
 You will need [Go](https://golang.org) 1.17 or higher to develop and build the plugin.
-
 
 ### Test
 
@@ -199,20 +216,18 @@ In order to create encrypted test data, you need to import the secret key from `
 
     cd testdata
     gpg --import keyring.gpg
-    
+
 You can then use `sops` to create encrypted files:
 
     sops -e -i newfile.txt
-
 
 ### Build
 
 Create a binary for your system:
 
     make
-    
-The resulting executable will be named `SopsSecretGenerator`.
 
+The resulting executable will be named `SopsSecretGenerator`.
 
 ### Release
 

--- a/SopsSecretGenerator.go
+++ b/SopsSecretGenerator.go
@@ -88,7 +88,7 @@ func usage() {
 	os.Exit(1)
 }
 
-var sopsDryRunPlaceholder = "SOPS_DRYRUN_PLACEHOLDER"
+var sopsDryRunPlaceholder = "SOPS_ENCRYPTED_DATA_OMITTED"
 
 func main() {
 	argsLen := len(os.Args)
@@ -358,7 +358,7 @@ func parseJSONContent(content []byte, data kvMap) error {
 
 func setValue(k string, v string, data kvMap) {
 	if isSopsDryRun() && !isSopsKey(k) {
-		data[k] = base64.StdEncoding.EncodeToString([]byte(sopsDryRunPlaceholder))
+		data[k] = sopsDryRunPlaceholder
 	} else if !isSopsDryRun() {
 		data[k] = base64.StdEncoding.EncodeToString([]byte(v))
 	}
@@ -405,7 +405,7 @@ func parseFileSource(source string, data kvMap) error {
 	}
 
 	if isSopsDryRun() {
-		data[key] = base64.StdEncoding.EncodeToString([]byte(sopsDryRunPlaceholder))
+		data[key] = sopsDryRunPlaceholder
 		return nil
 	}
 

--- a/SopsSecretGenerator.go
+++ b/SopsSecretGenerator.go
@@ -369,6 +369,12 @@ func decryptFile(source string) ([]byte, error) {
 		return nil, errors.Wrap(err, "could not read file")
 	}
 
+	_,found := os.LookupEnv("SOPS_DRY_RUN");
+
+	if (found) {
+		return content, nil;
+	}
+
 	decrypted, err := decrypt.DataWithFormat(content, formats.FormatForPath(source))
 	if err != nil {
 		return nil, errors.Wrap(err, "sops could not decrypt")

--- a/SopsSecretGenerator_test.go
+++ b/SopsSecretGenerator_test.go
@@ -171,8 +171,8 @@ func Test_ProcessSopsSecretGenerator_SopsDryRun(t *testing.T) {
 				metadata:
 				    name: secret
 				data:
-				    VAR_ENV: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
-				    file.txt: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
+				    VAR_ENV: SOPS_ENCRYPTED_DATA_OMITTED
+				    file.txt: SOPS_ENCRYPTED_DATA_OMITTED
 			`), "\n"),
 			false,
 		},

--- a/SopsSecretGenerator_test.go
+++ b/SopsSecretGenerator_test.go
@@ -503,6 +503,10 @@ func Test_parseDotEnvLine(t *testing.T) {
 	}{
 		{"Variable", args{b("VAR=value")}, []string{"VAR", "value"}, false},
 		{"TrimLeft", args{b("VAR=value")}, []string{"VAR", "value"}, false},
+		{"EmptyLine", args{b("")}, nil, false},
+		{"Comment", args{b("# Comment")}, nil, false},
+		{"NoValue", args{b("VAR")}, nil, true},
+		{"InvalidUTF8", args{[]byte{0xff, 0xfe, 0xfd}}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/SopsSecretGenerator_test.go
+++ b/SopsSecretGenerator_test.go
@@ -151,6 +151,48 @@ func Test_GenerateKRMManifest(t *testing.T) {
 	}
 }
 
+func Test_ProcessSopsSecretGenerator_SopsDryRun(t *testing.T) {
+	
+	type args struct {
+		fn string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"SopsSecretGenerator",
+			args{"testdata/generator-with-env.yaml"},
+			strings.TrimLeft(dedent.Dedent(`
+				apiVersion: v1
+				kind: Secret
+				metadata:
+				    name: secret
+				data:
+				    VAR_ENV: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
+				    file.txt: U09QU19EUllSVU5fUExBQ0VIT0xERVI=
+			`), "\n"),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SOPS_DRY_RUN", "true")
+			sopsSecretGeneratorManifest, _ := ioutil.ReadFile(tt.args.fn)
+			got, err := processSopsSecretGenerator(sopsSecretGeneratorManifest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("processSopsSecretGenerator() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("processSopsSecretGenerator() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_ProcessSopsSecretGenerator(t *testing.T) {
 	type args struct {
 		fn string
@@ -456,26 +498,21 @@ func Test_parseDotEnvLine(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    kvMap
+		want    []string
 		wantErr bool
 	}{
-		{"Variable", args{b("VAR=value")}, kvMap{"VAR": b64("value")}, false},
-		{"TrimLeft", args{b(" VAR=value")}, kvMap{"VAR": b64("value")}, false},
-		{"EmptyLine", args{b("")}, kvMap{}, false},
-		{"Comment", args{b("# Comment")}, kvMap{}, false},
-		{"NoValue", args{b("VAR")}, kvMap{}, true},
-		{"InvalidUTF8", args{[]byte{0xff, 0xfe, 0xfd}}, kvMap{}, true},
+		{"Variable", args{b("VAR=value")}, []string{"VAR", "value"}, false},
+		{"TrimLeft", args{b("VAR=value")}, []string{"VAR", "value"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := make(kvMap)
-			err := parseDotEnvLine(tt.args.line, got)
+			pair, err := parseDotEnvLine(tt.args.line)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseDotEnvLine() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseDotEnvLine() got = %v, want %v", got, tt.want)
+			}  
+			if !reflect.DeepEqual(pair, tt.want) {
+				t.Errorf("parseDotEnvLine() got = %v, want %v", pair, tt.want)
 			}
 		})
 	}

--- a/testdata/generator-with-env.yaml
+++ b/testdata/generator-with-env.yaml
@@ -1,0 +1,9 @@
+apiVersion: goabout.com/v1beta1
+kind: SopsSecretGenerator
+metadata:
+  name: secret
+disableNameSuffixHash: true
+files:
+  - testdata/file.txt
+envs:
+  - testdata/vars.env


### PR DESCRIPTION
This PR is providing an option to bypass SOPS runs when verifying only the kustomize overlay in CI workflows, enabled via an environment variable (SOPS_DRY_RUN).